### PR TITLE
Update lita-slack to 1.3.0

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -34,14 +34,15 @@ module Lita
         attr_reader :type
 
         def body
-          full_text = []
-          message_text = data["text"].to_s.sub(/^\s*<@#{robot_id}>/, "@#{robot.mention_name}")
-          full_text << message_text unless message_text == ''
-          data["attachments"].each do |attach|
-            next if attach["text"] == ( '' || nil )
-            full_text << attach["text"]
-          end if data["attachments"]
-          full_text.join("\n")
+          normalized_message = if data["text"]
+            data["text"].sub(/^\s*<@#{robot_id}>/, "@#{robot.mention_name}")
+          end
+
+          attachment_text = Array(data["attachments"]).map do |attachment|
+            attachment["text"]
+          end
+
+          ([normalized_message] + attachment_text).compact.join("\n")
         end
 
         def channel

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -34,7 +34,14 @@ module Lita
         attr_reader :type
 
         def body
-          data["text"].to_s.sub(/^\s*<@#{robot_id}>/, "@#{robot.mention_name}")
+          full_text = []
+          message_text = data["text"].to_s.sub(/^\s*<@#{robot_id}>/, "@#{robot.mention_name}")
+          full_text << message_text unless message_text == ''
+          data["attachments"].each do |attach|
+            next if attach["text"] == ( '' || nil )
+            full_text << attach["text"]
+          end if data["attachments"]
+          full_text.join("\n")
         end
 
         def channel

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-slack"
-  spec.version       = "1.2.0"
+  spec.version       = "1.3.0"
   spec.authors       = ["Ken J.", "Jimmy Cuadra"]
   spec.email         = ["kenjij@gmail.com", "jimmy@jimmycuadra.com"]
   spec.description   = %q{Lita adapter for Slack.}

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -99,6 +99,28 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
       end
 
+      context "when the message has attach" do
+        let(:data) do
+          {
+            "type" => "message",
+            "channel" => "C2147483705",
+            "user" => "U023BECGF",
+            "text" => "Hello",
+            "attachments" => [{"text" => "attached hello"}]
+          }
+        end
+
+        it "recives attachment text" do
+          expect(Lita::Message).to receive(:new).with(
+            robot,
+            "Hello\nattached hello",
+            source
+          ).and_return(message)
+
+          subject.handle
+        end
+      end
+
       context "when the message is nil" do
         let(:data) do
           {


### PR DESCRIPTION
## Explanation 
We need the "attachments" from the slack message, so I'm merging 1.3.0 to  our fork.

Note: I tried with latest version of the gem, but for some reason the messages sent from slackbot are not working as input to the handlers. I didn't a find a way to debug this :( 

After merge this, we can point `envoy-lita-slack` to master.