### PR TITLE
Handling slack actions inside message

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -39,10 +39,26 @@ module Lita
           end
 
           attachment_text = Array(data["attachments"]).map do |attachment|
-            attachment["text"]
+            if attachment['actions']
+              parse_attachment_with_actions(attachment)
+            else
+              attachment["text"]
+            end
           end
 
           ([normalized_message] + attachment_text).compact.join("\n")
+        end
+
+        # https://api.slack.com/actions
+        def parse_attachment_with_actions(attachment)
+          lines = []
+          lines << attachment["text"]
+          Array(attachment["actions"]).map do |field|
+            lines << field["name"]
+            lines << field["text"]
+            lines << field["value"]
+          end
+          lines.compact.map(&:strip).reject(&:empty?)
         end
 
         def channel

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -121,6 +121,48 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
       end
 
+      context "when the message has attachments with actions" do
+        let(:action) do
+          {
+            "id"=>"1",
+            "name"=>"actionexample",
+            "text"=>"Action Example",
+            "type"=>"button",
+            "value"=> "{\"token\":\"xoxb-abcd\",\"callbackUrl\":\"http://sample.com/action\"}",
+            "style"=>""
+          }
+        end
+        let(:attachment_with_actions) do
+          {
+            "callback_id"=>"callback",
+            "text"=>"Fallback Text",
+            "id"=>1,
+            "color"=>"ef3934",
+            "actions"=> [action],
+            "fallback"=>"Fallback Text"
+          }
+        end
+        let(:data) do
+          {
+            "type" => "message",
+            "channel" => "C2147483705",
+            "user" => "U023BECGF",
+            "text" => "Hello",
+            "attachments" => [attachment_with_actions]
+          }
+        end
+
+        it "recives attachment text with the action information" do
+          expect(Lita::Message).to receive(:new).with(
+            robot,
+            "Hello\nFallback Text\nactionexample\nAction Example\n{\"token\":\"xoxb-abcd\",\"callbackUrl\":\"http://sample.com/action\"}",
+            source
+          ).and_return(message)
+
+          subject.handle
+        end
+      end
+
       context "when the message is nil" do
         let(:data) do
           {


### PR DESCRIPTION
## Explanation

our lita-slack doesn't support the slack messages with actions https://api.slack.com/actions and since switch to use Slack Action buttons for deliveries slack notifications, we need to support this somehow.

This is a very basic PR so we can continue using the canary

Note: I'm planing to make a better PR to the oficial repository, however there is a related discussion about this on:

https://github.com/litaio/lita-slack/issues/97
https://github.com/litaio/lita/issues/192
https://github.com/litaio/lita-slack/pull/93

and also the last time I checked (december 2007/ https://github.com/envoy/lita-slack/pull/1) the latest version of this gem didn't worked for us, but I'm planing to give this another try.

## TODO:

- [x] Update https://github.com/envoy/envoy-lita-slack to point the latest version of this